### PR TITLE
Add tests of `JsonLd::Builder`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bundle/
+coverage/
 gemfiles/*.lock
 Gemfile.lock
 log/*.log

--- a/README.md
+++ b/README.md
@@ -35,8 +35,5 @@ Or install it yourself as:
 $ gem install breadcrumbs_on_rails-json_ld
 ```
 
-## TODO
-* Add tests
-
 ## License
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/Rakefile
+++ b/Rakefile
@@ -16,4 +16,6 @@ end
 
 require "bundler/gem_tasks"
 
+require "rspec/core/rake_task"
+RSpec::Core::RakeTask.new(:spec)
 task default: :spec

--- a/lib/breadcrumbs_on_rails/json_ld/builder.rb
+++ b/lib/breadcrumbs_on_rails/json_ld/builder.rb
@@ -20,7 +20,7 @@ module BreadcrumbsOnRails
           "@type" => "ListItem",
           "position" => index,
           "item" => {
-            "@id" => URI.join(@context.root_url, compute_path(element)),
+            "@id" => URI.join(@context.root_url, compute_path(element)).to_s,
             "name" => compute_name(element),
           },
         }

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -1,0 +1,10 @@
+inherit_from:
+  - ../.rubocop.yml
+
+# Allow using `{...}` anytime
+Style/BlockDelimiters:
+  Enabled: false
+
+# BlockLength almost equals to MethodLength in spec files
+Metrics/BlockLength:
+  Max: 200

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  root to: "dummy#dummy"
+
+  get "foo" => "dummy#dummy"
 end

--- a/spec/lib/breadcrumbs_on_rails/json_ld/builder_spec.rb
+++ b/spec/lib/breadcrumbs_on_rails/json_ld/builder_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BreadcrumbsOnRails::JsonLd::Builder, type: :helper do
+  subject { helper.render_breadcrumbs(builder: described_class) }
+
+  let(:expectation) do
+    JSON.pretty_generate(
+      "@context": "http://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": expected_item_list_element,
+    )
+  end
+
+  context "when #add_breadcrumb is not called in advance" do
+    let(:expected_item_list_element) { [] }
+    it { is_expected.to eq expectation }
+  end
+
+  context "when #add_breadcrumb is called in advance" do
+    before do
+      helper.add_breadcrumb("root", :root_path)
+      helper.add_breadcrumb("foo", proc { |c| c.foo_path })
+      helper.add_breadcrumb("bar", "/foo/bar")
+    end
+
+    let(:expected_item_list_element) do
+      [
+        {
+          "@type": "ListItem",
+          position: 1,
+          item: {
+            "@id": "http://test.host/",
+            name: "root",
+          },
+        },
+        {
+          "@type": "ListItem",
+          position: 2,
+          item: {
+            "@id": "http://test.host/foo",
+            name: "foo",
+          },
+        },
+        {
+          "@type": "ListItem",
+          position: 3,
+          item: {
+            "@id": "http://test.host/foo/bar",
+            name: "bar",
+          },
+        },
+      ]
+    end
+
+    it { is_expected.to eq expectation }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,9 @@
 
 require "simplecov"
 
-SimpleCov.start
+SimpleCov.start do
+  add_filter "/spec/"
+end
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,6 +49,12 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin
@@ -85,12 +91,6 @@ RSpec.configure do |config|
   # end of the spec run, to help surface which specs are running
   # particularly slow.
   config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce


### PR DESCRIPTION
This PR adds some changes to

* test `JsonLd::Builder`
* relax RuboCop rules for tests
* run tests at random

And also it fixes the following bugs:

* `rake` command does nothing
* `URI::HTTP#to_json` returns not a string but an object of JSON in Rails 4.0
* The spec files are used to calculate the test coverage