### PR TITLE
Fixed issue with umlauts

### DIFF
--- a/lib/breadcrumbs_on_rails/json_ld/builder.rb
+++ b/lib/breadcrumbs_on_rails/json_ld/builder.rb
@@ -20,7 +20,7 @@ module BreadcrumbsOnRails
           "@type" => "ListItem",
           "position" => index,
           "item" => {
-            "@id" => URI.join(@context.root_url, compute_path(element)).to_s,
+            "@id" => URI.join(@context.root_url, URI.escape(compute_path(element))).to_s,
             "name" => compute_name(element),
           },
         }


### PR DESCRIPTION
When using allowed umlauts in the URI they was not escaped and so the method URI.join crashed.

Please pull, so I have not to monkey patch. :-)